### PR TITLE
go get already installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This program depends on a Go 1.1 installation.  One can use a remote
 `go get` and then `go install` to compile it from source:
 
     $ go get github.com/htcat/htcat/cmd/htcat
-    $ go install github.com/htcat/htcat/cmd/htcat
 
 ## Help and Reporting Bugs ##
 


### PR DESCRIPTION
The `go get` tool already compile and install the package. `go get -d` can be used to only download the source but that is not the default.

Simply remove the unnecessary line from the README.
