### PR TITLE
Implement buffer pool to reduce memory use and allocations.

### DIFF
--- a/eager_reader_test.go
+++ b/eager_reader_test.go
@@ -11,7 +11,7 @@ func TestEagerReaderRead(t *testing.T) {
 	reader, writer := io.Pipe()
 	payload := []byte("hello")
 
-	er := newEagerReader(ioutil.NopCloser(reader), int64(len(payload)))
+	er := newEagerReader(ioutil.NopCloser(reader), int64(len(payload)), nil)
 	done := make(chan struct{})
 
 	go func() {

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,55 @@
+package htcat
+
+import "sync"
+
+// A pool is a pool of reusable buffers of a set size. Size should be equal to
+// the requests fragment size.
+type pool struct {
+	size int64
+	bufs [][]byte
+	mu   sync.Mutex
+}
+
+// newPool, Returns a new pool with a capicatiy of cap.  Only slices with a
+// length of size will be stored in the pool.
+func newPool(cap int, size int64) *pool {
+	return &pool{
+		bufs: make([][]byte, 0, cap),
+		size: size,
+		mu:   sync.Mutex{},
+	}
+}
+
+// Put, attempts to put byte slice b into the pool.  If the pool is full or if
+// the length of p does not equal the pools size it will be discarded.
+func (p *pool) Put(b []byte) {
+	p.mu.Lock()
+	if int64(len(b)) == p.size && len(p.bufs) < cap(p.bufs) {
+		p.bufs = append(p.bufs, b)
+	}
+	p.mu.Unlock()
+}
+
+// Get, returns a byte slice of size n.  If the pool is empty or n is greater
+// than the pools buffer size a new byte slice is made.
+func (p *pool) Get(n int64) (buf []byte) {
+	p.mu.Lock()
+	if ln := len(p.bufs); ln != 0 && n <= p.size {
+		buf = p.bufs[ln-1][:n]
+		p.bufs = p.bufs[:ln-1]
+	} else {
+		buf = make([]byte, n)
+	}
+	p.mu.Unlock()
+	return buf
+}
+
+// Free, sets the pool's buffer to nil so that lingering references do not
+// prevent the garbage collector from reclaiming the pools contents.
+func (p *pool) Free() {
+	if p != nil {
+		p.mu.Lock()
+		p.bufs = nil
+		p.mu.Unlock()
+	}
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,120 @@
+package htcat
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestPoolCap(t *testing.T) {
+	const (
+		capacity = 5
+		size     = 5
+	)
+	p := newPool(capacity, size)
+	if cap(p.bufs) != capacity {
+		t.Errorf("expected buffer capacity of %d, got %d", capacity, cap(p.bufs))
+	}
+	for i := 0; i < capacity+1; i++ {
+		p.Put(make([]byte, size))
+	}
+	if cap(p.bufs) != capacity {
+		t.Errorf("expected buffer capacity of %d, got %d", capacity, cap(p.bufs))
+	}
+	if len(p.bufs) != capacity {
+		t.Errorf("expected buffer size of %d, got %d", capacity, len(p.bufs))
+	}
+}
+
+func TestPoolPut(t *testing.T) {
+	const (
+		capacity = 5
+		size     = 5
+	)
+	p := newPool(capacity, size)
+	bb := [][]byte{
+		make([]byte, size),
+		make([]byte, size+1),
+		make([]byte, size-1),
+	}
+	for _, b := range bb {
+		p.Put(b)
+	}
+	if len(p.bufs) != 1 {
+		t.Errorf("expected buffer size of %d, got %d", 1, len(p.bufs))
+	}
+}
+
+func TestPoolGet(t *testing.T) {
+	const (
+		capacity = 10
+		size     = 5
+	)
+	p := newPool(capacity, size)
+	bb := [][]byte{
+		make([]byte, size),
+		make([]byte, size),
+		make([]byte, size),
+	}
+	ps := make(map[uintptr]bool, len(bb))
+	for i := 0; i < len(bb); i++ {
+		ps[reflect.ValueOf(bb[i]).Pointer()] = true
+		p.Put(bb[i])
+	}
+
+	var b []byte
+
+	// Test that buffers are returned from the pool.
+	for i := len(bb) - 1; i > 0; i-- {
+		b = p.Get(size)
+		if !ps[reflect.ValueOf(b).Pointer()] {
+			t.Error("pool failed to return a buffer from the pool")
+		}
+	}
+
+	// Test that requests for smaller buffers return a buffer from the pool.
+	b = p.Get(size - 1)
+	if !ps[reflect.ValueOf(b).Pointer()] {
+		t.Error("pool failed to return a smaller buffer from the pool")
+	}
+	if len(b) != size-1 {
+		t.Error("invalid buffer size")
+	}
+
+	// Test that a new slice is made when the buffer is empty.
+	b = p.Get(size)
+	if ps[reflect.ValueOf(b).Pointer()] {
+		t.Error("pool returned a buffer that is currently in use")
+	}
+	b = p.Get(size + 1)
+	if len(b) != size+1 {
+		t.Error("invalid buffer size")
+	}
+	b = p.Get(size - 1)
+	if len(b) != size-1 {
+		t.Error("invalid buffer size")
+	}
+}
+
+// Test that the GC collects the pools buffer after a call to free.
+func TestPoolFree(t *testing.T) {
+	const (
+		capacity = 10
+		size     = mB * 10
+	)
+	var m [2]runtime.MemStats
+	p := newPool(capacity, size)
+	for i := 0; i < capacity; i++ {
+		p.Put(make([]byte, size))
+	}
+	runtime.ReadMemStats(&m[0])
+	p.Free()
+	if p.bufs != nil {
+		t.Error("failed to free buffer pool")
+	}
+	runtime.GC()
+	runtime.ReadMemStats(&m[1])
+	if m[1].Alloc >= m[0].Alloc {
+		t.Error("failed to free buffer")
+	}
+}


### PR DESCRIPTION
Implement a pool of buffers for eagerReader to reduce allocations and improve performance.  This reduces allocations to roughly (parallelism \* targetFragSize), a few additional buffers may be allocated depending on the timing of each response.  Previously htcat allocated buffers equivalent to the size of the request.

To minimize changes to the programs overall structure it was required to provide the eagerReader a pointer to the buffer pool held by defrag in order to free its buffer on close.  HtCat's noParallel "short-circut" path or a non-200 status code from the initial response result in defrag holding a nil pool, therefore eagerReader can accept a nil pool and the pool checks if it is nil on calls to close - otherwise it will panic.
