### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/defrag.go
+++ b/defrag.go
@@ -93,7 +93,7 @@ func (d *defrag) cancel(err error) {
 	d.cancelNotify <- err
 }
 
-// Write the contents of the defragmenter out to the io.Writer dst.
+// WriteTo writes the contents of the defragmenter out to the io.Writer dst.
 func (d *defrag) WriteTo(dst io.Writer) (written int64, err error) {
 	defer close(d.done)
 


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._