### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/defrag.go
+++ b/defrag.go
@@ -93,7 +93,7 @@ func (d *defrag) cancel(err error) {
 	d.cancelNotify <- err
 }
 
-// Write the contents of the defragmenter out to the io.Writer dst.
+// WriteTo writes the contents of the defragmenter out to the io.Writer dst.
 func (d *defrag) WriteTo(dst io.Writer) (written int64, err error) {
 	defer close(d.done)
 


### PR DESCRIPTION
Fix function comments following [Effective Go Guidelines](https://golang.org/doc/effective_go.html#commentary)